### PR TITLE
fix(dashy): use dedicated icon for Donetick

### DIFF
--- a/cluster/apps/dashy/dashy.yaml
+++ b/cluster/apps/dashy/dashy.yaml
@@ -71,7 +71,7 @@ data:
             url: https://mealie.{{SECRET_DOMAIN}}
             statusCheckUrl: http://mealie.mealie.svc.cluster.local:9000
           - title: Donetick
-            icon: fas fa-list-check
+            icon: hl-donetick
             url: https://donetick.{{SECRET_DOMAIN}}
             statusCheckUrl: http://donetick.donetick.svc.cluster.local:2021
             displayData:


### PR DESCRIPTION
## Summary
- Donetick was using a generic Font Awesome icon (`fas fa-list-check`) instead of its own logo
- Switched to `hl-donetick`, matching the convention used for other apps (Mealie, Joplin, Dawarich, etc.)

## Test plan
- [x] `kluctl diff -t cluster --include-tag dashy` to preview
- [x] Deploy and confirm the Donetick icon renders correctly in Dashy