### PR TITLE
fix(mosquitto): pin explicit Reloader annotation for TLS cert secret

### DIFF
--- a/cluster/apps/home-automation/mosquitto/mosquitto.yaml
+++ b/cluster/apps/home-automation/mosquitto/mosquitto.yaml
@@ -8,6 +8,7 @@ metadata:
     app.kubernetes.io/instance: mosquitto
   annotations:
     reloader.stakater.com/auto: "true"
+    secret.reloader.stakater.com/reload: "mosquitto-certs"
 spec:
   replicas: 1
   selector:


### PR DESCRIPTION
## Summary
- Reloader's `auto` annotation only reliably auto-discovers ConfigMaps/Secrets whose name matches the Deployment name (known limitation, see [stakater/Reloader#820](https://github.com/stakater/Reloader/issues/820))
- Deployment `mosquitto` matches ConfigMap `mosquitto` (worked) but not Secret `mosquitto-certs` (never triggered)
- Result: cert-manager renewed the mosquitto TLS certificate several times over 94 days, but the mosquitto pod never restarted to pick it up — it kept serving the certificate loaded at pod startup, which eventually expired and broke all MQTT connections (including Home Assistant)
- Fix: add explicit `secret.reloader.stakater.com/reload: "mosquitto-certs"` annotation so Reloader restarts mosquitto whenever cert-manager rotates the cert

## Test plan
- [x] `yamllint` passes on the modified file
- [x] Manually restarted mosquitto in the live cluster to recover from the current expired-cert outage (out of band of this PR)
- [ ] After merge/deploy, confirm the Deployment gains a `STAKATER_MOSQUITTO_CERTS_SECRET` env var on the next `cert-manager` renewal (~2026-08-14) and that mosquitto restarts automatically