### PR TITLE
fix(media-automation): switch radarr/sonarr/prowlarr to docker.io registry

### DIFF
--- a/cluster/apps/media-automation/prowlarr/prowlarr.yaml
+++ b/cluster/apps/media-automation/prowlarr/prowlarr.yaml
@@ -33,7 +33,7 @@ spec:
     spec:
       containers:
         - name: prowlarr
-          image: lscr.io/linuxserver/prowlarr:2.3.5.5327-ls144
+          image: docker.io/linuxserver/prowlarr:2.3.5.5327-ls144
           ports:
             - containerPort: 9696
               name: http

--- a/cluster/apps/media-automation/radarr/radarr.yaml
+++ b/cluster/apps/media-automation/radarr/radarr.yaml
@@ -33,7 +33,7 @@ spec:
     spec:
       containers:
         - name: radarr
-          image: lscr.io/linuxserver/radarr:6.1.1.10360-ls300
+          image: docker.io/linuxserver/radarr:6.1.1.10360-ls300
           ports:
             - containerPort: 7878
               name: http

--- a/cluster/apps/media-automation/sonarr/sonarr.yaml
+++ b/cluster/apps/media-automation/sonarr/sonarr.yaml
@@ -33,7 +33,7 @@ spec:
     spec:
       containers:
         - name: sonarr
-          image: lscr.io/linuxserver/sonarr:4.0.17.2952-ls309
+          image: docker.io/linuxserver/sonarr:4.0.17.2952-ls309
           ports:
             - containerPort: 8989
               name: http


### PR DESCRIPTION
## Summary
- lscr.io/ghcr.io list Docker tags oldest-first; radarr, sonarr, and prowlarr each have thousands of tags (arch variants, nightly, develop builds), so Renovate's pagination never reached the newer `-ls` tags and never proposed an update for these three images.
- docker.io returns tags newest-first, so switching the registry fixes discovery without any other config change.
- Verified all three current tags still resolve on docker.io, and that the newest known tags (e.g. radarr `6.3.0.10514-ls313`) are now reachable.

## Test plan
- [ ] `kluctl deploy` the media-automation stack and confirm radarr/sonarr/prowlarr pull successfully from docker.io
- [ ] Watch the Renovate dashboard next run for update PRs on these three images